### PR TITLE
Handled infinite while loop in automated.py

### DIFF
--- a/orbitdeterminator/automated.py
+++ b/orbitdeterminator/automated.py
@@ -54,7 +54,7 @@ def stage(processed):
     for file in processed:
         print("staging")
         run(
-            "cd %s;git add %s" % (SOURCE_ABSOLUTE, file),
+            "cd %s;git add '%s'" % (SOURCE_ABSOLUTE, file),
             stdout=PIPE, stderr=PIPE,
             universal_newlines=True,
             shell=True
@@ -166,7 +166,7 @@ def main():
                 print("\nAll untracked files have been processed")
             print("Add new files in /src folder to process them")
             time_elapsed = 0
-            timeout = 20
+            timeout = 30
             while (time_elapsed <= timeout and not raw_files):
                 sys.stdout.write("\r")
                 sys.stdout.write("-> Timeout in - {:2d} s".format(timeout - time_elapsed))

--- a/orbitdeterminator/automated.py
+++ b/orbitdeterminator/automated.py
@@ -6,6 +6,8 @@ along with a plot and a filtered csv data file. Both the generated results lie i
 '''
 
 import os
+import time
+import sys
 import numpy as np
 import matplotlib as mpl
 from subprocess import (PIPE, run)
@@ -154,11 +156,28 @@ def process(data_file, error_apriori, name):
 
 def main():
 
+    number_untracked = 0
     while True:
         raw_files = untracked_files()
         if not raw_files:
+            if (number_untracked == 0):
+                print("\nNo unprocessed file found in src/folder")
+            else:
+                print("\nAll untracked files have been processed")
+            print("Add new files in /src folder to process them")
+            time_elapsed = 0
+            timeout = 20
+            while (time_elapsed <= timeout and not raw_files):
+                sys.stdout.write("\r")
+                sys.stdout.write("-> Timeout in - {:2d} s".format(timeout - time_elapsed))
+                sys.stdout.flush()
+                time.sleep(1)
+                time_elapsed += 1
+                raw_files = untracked_files()
+            sys.stdout.write("\r                        \n")
             pass
-        else:
+        if raw_files:
+            number_untracked += len(raw_files)
             for file in raw_files:
                 print("processing")
                 a = read_data.load_data(SOURCE_ABSOLUTE + "/" + file)
@@ -166,6 +185,10 @@ def main():
                 process(a, 10.0, str(file)[:-4])
                 print("File : %s has been processed \n \n" % file)
             stage(raw_files)
+            continue
+        print("No new unprocessed file was added, program is now exiting due to timeout!")
+        print("Total {} untracked files were processed".format(number_untracked))
+        break
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Commit e2574255507aba631ba62b1bc2b53f819efaab72 fixed the problem stated in issue #146, in the example below timeout time has been set to 20 seconds for short length of GIF but it can be set to any value

![PR_issue_orbitdeterminator](https://user-images.githubusercontent.com/28908101/54327241-76ad8000-462f-11e9-9cc0-735331ad40e8.gif)

For issue #148:
For this part of code in automated.py-
```
def stage(processed):

    for file in processed:
        print("staging")
        run(
            "cd %s;git add %s" % (SOURCE_ABSOLUTE, file),
            stdout=PIPE, stderr=PIPE,
            universal_newlines=True,
            shell=True
        )
        print("File %s has been staged." % (file))
```
code which is effectively running in bash for file "Test File.csv" is:
`git add Test Case.csv`
which will do nothing as for special characters bash (ubuntu) needs code like this:
`git add Test\ Case.csv`

It can be handeled if we pass '%s' instead of %s since in src folder `git add 'Test File.csv'` will work perfectly fine, new code will be like this-
```
run(
            "cd %s;git add '%s'" % (SOURCE_ABSOLUTE, file),
            stdout=PIPE, stderr=PIPE,
            universal_newlines=True,
            shell=True
        )
```
- Working of script after both fixes
![PR_commit2_issue_orbitdeterminator](https://user-images.githubusercontent.com/28908101/54329174-985e3580-4636-11e9-90f6-c9927d31cce8.gif)
