### PR TITLE
Added Exception for IndexError in Lamberts Kalman

### DIFF
--- a/orbitdeterminator/kep_determination/lamberts_kalman.py
+++ b/orbitdeterminator/kep_determination/lamberts_kalman.py
@@ -218,7 +218,12 @@ def kalman(kep, R):
         Pminus = 0.0  # a priori error estimate
         K = 0.0  # gain or blending factor
         # intial guesses
-        xhat = np.mean(kep[:, i])
+        try:
+            xhat = np.mean(kep[:, i])
+        except IndexError as err:
+            print('Error: {0} \n ** Switching units to metres might help **'.format(err))
+            quit()
+            
         P = 1.0
         for k in range(1, n_iter):
             # time update


### PR DESCRIPTION
Hi,
When running OD using Lamberts Kalman method `xhat = np.mean(kep[:, I])` in `kalman_lambert.kalman`  will result in `IndexError `because the distance units are in km. Changing the units to metres fixes the issue.

But currently, there is no error handling. This commit adds a simple try-except block for IndexError which returns a message requesting the user to change units to metres.
Use this command - `python3 main.py -u m`

![image](https://user-images.githubusercontent.com/12347532/79046439-9a763780-7c2e-11ea-9ecf-96ae8521c434.png)

Thanks!

Originally mentioned by @aryadas98 in #106 (comment)

Edit: closed #190 to squash and shift branch 