### PR TITLE
fixed links to libs

### DIFF
--- a/orbitdeterminator/tests/test_check_keplerian.py
+++ b/orbitdeterminator/tests/test_check_keplerian.py
@@ -1,7 +1,7 @@
 import sys
 import os.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-from orbitdeterminator.kep_determination import lamberts_kalman
+from kep_determination import lamberts_kalman
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/orbitdeterminator/tests/test_input_transf.py
+++ b/orbitdeterminator/tests/test_input_transf.py
@@ -1,7 +1,7 @@
 import sys
 import os.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-from orbitdeterminator.util import input_transf
+from util import input_transf
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/orbitdeterminator/tests/test_kalman.py
+++ b/orbitdeterminator/tests/test_kalman.py
@@ -1,7 +1,7 @@
 import sys
 import os.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-from orbitdeterminator.kep_determination import lamberts_kalman
+from kep_determination import lamberts_kalman
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/orbitdeterminator/tests/test_lamberts_kalman.py
+++ b/orbitdeterminator/tests/test_lamberts_kalman.py
@@ -1,7 +1,7 @@
 import sys
 import os.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-from orbitdeterminator.kep_determination import (lamberts_kalman, interpolation)
+from kep_determination import (lamberts_kalman, interpolation)
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/orbitdeterminator/tests/test_orbit_trajectory.py
+++ b/orbitdeterminator/tests/test_orbit_trajectory.py
@@ -1,7 +1,7 @@
 import sys
 import os.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-from orbitdeterminator.kep_determination import lamberts_kalman
+from kep_determination import lamberts_kalman
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal


### PR DESCRIPTION
wrong paths to some links fixed.

when called with python3.7 64bit windows10, it failed.
the paths lead to places where there those python files were not.
now they run. shoul dbe tested.