### PR TITLE
 Installation of pykep Anaconda Distrubtion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ poliastro >= 0.9.1
 py >= 1.5.2
 pyephem >= 3.7.6.0
 pykep >= 2.1
-Anaconda Distrubtion = Step 1.conda config --add channels conda-forge  Step 2.conda config --set channel_priority strict Step 3.conda install pykep
+conda config --add channels conda-forge 
+conda config --set channel_priority strict 
+conda install pykep
 pyparsing >= 2.2.0
 pytest >= 3.4.0
 python-dateutil >= 2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ poliastro >= 0.9.1
 py >= 1.5.2
 pyephem >= 3.7.6.0
 pykep >= 2.1
+Anaconda Distrubtion = Step 1.conda config --add channels conda-forge  Step 2.conda config --set channel_priority strict Step 3.conda install pykep
 pyparsing >= 2.2.0
 pytest >= 3.4.0
 python-dateutil >= 2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ poliastro >= 0.9.1
 py >= 1.5.2
 pyephem >= 3.7.6.0
 pykep >= 2.1
-pip install pdbpp
+pdbpp
 pyparsing >= 2.2.0
 pytest >= 3.4.0
 python-dateutil >= 2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ poliastro >= 0.9.1
 py >= 1.5.2
 pyephem >= 3.7.6.0
 pykep >= 2.1
-conda config --add channels conda-forge 
-conda config --set channel_priority strict 
+pip install pdbpp
 pyparsing >= 2.2.0
 pytest >= 3.4.0
 python-dateutil >= 2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ pyephem >= 3.7.6.0
 pykep >= 2.1
 conda config --add channels conda-forge 
 conda config --set channel_priority strict 
-conda install pykep
 pyparsing >= 2.2.0
 pytest >= 3.4.0
 python-dateutil >= 2.6.1


### PR DESCRIPTION
pykep is available via the conda package manager for Linux, OSX, and Windows thanks to the infrastructure provided by conda-forge. In order to install pykep via conda, you just need to add conda-forge to the channels, and then you can immediately install pykep: